### PR TITLE
Use full class name replacement when constructing css selector.

### DIFF
--- a/src/optimize.js
+++ b/src/optimize.js
@@ -127,8 +127,8 @@ function optimizePart (prePart, current, postPart, elements) {
                                          .map((name) => `.${name}`)
                                          .sort((curr, next) => curr.length - next.length)
     while (names.length) {
-      const reg = new RegExp(`( )(${names.shift()})( |$)`);
-      const partial = current.split('.').join(' .').replace(reg,'').split(' ').filter(Boolean).join('');
+      names = names.slice(1);
+      const partial = names.join('');
 
       var pattern = `${prePart}${partial}${postPart}`.trim()
       if (!pattern.length || pattern.charAt(0) === '>' || pattern.charAt(pattern.length-1) === '>') {

--- a/src/optimize.js
+++ b/src/optimize.js
@@ -127,7 +127,9 @@ function optimizePart (prePart, current, postPart, elements) {
                                          .map((name) => `.${name}`)
                                          .sort((curr, next) => curr.length - next.length)
     while (names.length) {
-      const partial = current.replace(names.shift(), '').trim()
+      const reg = new RegExp(`( )(${names.shift()})( |$)`);
+      const partial = current.split('.').join(' .').replace(reg,'').split(' ').filter(Boolean).join('');
+
       var pattern = `${prePart}${partial}${postPart}`.trim()
       if (!pattern.length || pattern.charAt(0) === '>' || pattern.charAt(pattern.length-1) === '>') {
         break


### PR DESCRIPTION
### Why do we need this change?
When we're trimming down the css selector for a particular element, we use partial replace which turns selector such as `node-123.node.blue_img` into `-123.node.blue_image` when given replacement value "node". Then we try to see if this element exists on the page by providing the shortened selector as an argument to `querySelectorAll` which throws an error:
_-123.node.blue_image is not a valid selector._
This error causes mapping to fail when selecting an element in website data sources mapping editor.

We should replace full class names as opposed to partial replacement.

### zendesk ticket: 
https://movableink.zendesk.com/agent/tickets/43554

[:house: [ch20103]](https://app.clubhouse.io/movableink/story/20103)